### PR TITLE
Fixed DPM_HOST and DPNS_HOST in xrootd environment

### DIFF
--- a/manifests/disknode.pp
+++ b/manifests/disknode.pp
@@ -226,6 +226,8 @@ class dpm::disknode (
     if $xrd_report or $xrootd_monitor {
       class{'dmlite::xrootd':
         nodetype             => [ 'disk' ],
+        dpmhost              => $headnode_fqdn,
+        nshost               => $headnode_fqdn,
 	domain               => $localdomain,
 	dpm_xrootd_debug     => $debug,
 	dpm_xrootd_sharedkey => $xrootd_sharedkey,
@@ -238,6 +240,8 @@ class dpm::disknode (
      } else {
        class{'dmlite::xrootd':
           nodetype             => [ 'disk' ],
+          dpmhost              => $headnode_fqdn,
+          nshost               => $headnode_fqdn,
           domain               => $localdomain,
           dpm_xrootd_debug     => $debug,
           dpm_xrootd_sharedkey => $xrootd_sharedkey,


### PR DESCRIPTION
Without explicitly specifying 'dmlite::xrootd' parameters "dpmhost" and "nshost" I get in disknode environment wrong name of DPM_HOST and DPNS_HOST with default $::fqdn. Either fix invalid value by this patch or in case you don't need those variables please get rid of them from xrootd environment - invalid value is confusing.