### PR TITLE
Remove DPM FTPHEAD in case gridftp_redirect is set to 0

### DIFF
--- a/manifests/headnode.pp
+++ b/manifests/headnode.pp
@@ -193,6 +193,11 @@ class dpm::headnode (
              protohead => "FTPHEAD",
              host      => "${headnode_fqdn}",
         } ~>  Class[dmlite::srm::service]
+      } else {
+        lcgdm::shift::unset{"GRIDFTP":
+             component => "DPM",
+             type      => "FTPHEAD",
+        } ~>  Class[dmlite::srm::service]
       }
     }
     if($configure_vos){


### PR DESCRIPTION
In case gridftp_redirect is disabled (changed from enabled state) in headnode configuration, DPM FTPHEAD must be removed from /etc/shift.conf otherwise DPM configuration managed by puppet will not work properly.