### PR TITLE
Simplify APEL StAR accounting usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ As well for the WedDav frontend, installed and enabled by default but it can be 
 Other parameters are:
 
 * **configure_bdii** :  enabled/disabled the configuration of Resource BDII ( default = true)
+* **configure_star** :  enabled/disabled the configuration of APEL StAR accounting ( default = true)
 * **configure_default_pool** : create the pools specified in the pools paramter ( default = false)
 * **configure_default_filesystem** : create the filesytems  specified in the filesystems parameter ( default = false)
 

--- a/manifests/head_disknode.pp
+++ b/manifests/head_disknode.pp
@@ -2,6 +2,7 @@ class dpm::head_disknode (
     $configure_vos =  $dpm::params::configure_vos,
     $configure_gridmap =  $dpm::params::configure_gridmap,
     $configure_bdii = $dpm::params::configure_bdii,
+    $configure_star = $dpm::params::configure_star,
     $configure_default_pool = $dpm::params::configure_default_pool,
     $configure_default_filesystem = $dpm::params::configure_default_filesystem,
     $configure_repos = $dpm::params::configure_repos,
@@ -327,8 +328,15 @@ class dpm::head_disknode (
           site_name => $site_name,
         }
       }
-
     } 
+
+    if ($configure_star)
+    {
+      class{'dmlite::accounting':
+        site_name => $site_name,
+      }
+    }
+
     #pools configuration
     #
     if ($configure_default_pool) {

--- a/manifests/headnode.pp
+++ b/manifests/headnode.pp
@@ -5,6 +5,7 @@ class dpm::headnode (
     $configure_vos =  $dpm::params::configure_vos,
     $configure_gridmap =  $dpm::params::configure_gridmap,
     $configure_bdii = $dpm::params::configure_bdii,
+    $configure_star = $dpm::params::configure_star,
     $configure_default_pool = $dpm::params::configure_default_pool,
     $configure_default_filesystem = $dpm::params::configure_default_filesystem,
     $configure_repos = $dpm::params::configure_repos,
@@ -339,6 +340,13 @@ class dpm::headnode (
        }
      }
 
+   }
+
+   if ($configure_star)
+   {
+     class{'dmlite::accounting':
+       site_name => $site_name,
+     }
    }
 
    if($configure_default_pool)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,6 +2,7 @@ class dpm::params {
   $configure_vos =  hiera('dpm::params::configure_vos', true)
   $configure_gridmap =  hiera('dpm::params::configure_gridmap', true)
   $configure_bdii =  hiera('dpm::params::configure_bdii', true)
+  $configure_star =  hiera('dpm::params::configure_star', true)
   $configure_default_pool = hiera('dpm::params::configure_default_pool',false)
   $configure_default_filesystem = hiera('dpm::params::configure_default_filesystem',false)
   $configure_repos =  hiera('dpm::params::configure_repos', false)


### PR DESCRIPTION
Enable APEL StAR accounting by default and make it configurable simply by
```puppet
class { 'dpm::headnode':
  ...
  configure_star => false,
  ...
}
```